### PR TITLE
Update for bookworm(debian12)

### DIFF
--- a/gadget/ipod_audio.c
+++ b/gadget/ipod_audio.c
@@ -553,15 +553,21 @@ int ipod_audio_bind(struct usb_configuration *conf, struct usb_function *func)
 
 	snd_pcm_set_ops(audio->pcm, SNDRV_PCM_STREAM_PLAYBACK, &ipod_audio_pcm_ops);
 	
-	#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,1,0)
-	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,snd_dma_continuous_data(GFP_KERNEL), 0, BUFFER_BYTES_MAX);
+	
+	#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+		snd_pcm_lib_preallocate_pages_for_all(audio->pcm,
+			SNDRV_DMA_TYPE_CONTINUOUS,
+			snd_dma_continuous_data(GFP_KERNEL,)
+			0,
+			BUFFER_BYTES_MAX);
 	#else
-	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,NULL, 0, BUFFER_BYTES_MAX);
+		snd_pcm_lib_preallocate_pages_for_all(audio->pcm,
+			SNDRV_DMA_TYPE_CONTINUOUS,
+			NULL,
+			0,
+			BUFFER_BYTES_MAX);
 	#endif
-	
-	
-	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,
-										  snd_dma_continuous_data(GFP_KERNEL), 0, BUFFER_BYTES_MAX);
+
 	ret = snd_card_register(audio->card);
 	if (ret)
 	{

--- a/gadget/ipod_audio.c
+++ b/gadget/ipod_audio.c
@@ -552,6 +552,14 @@ int ipod_audio_bind(struct usb_configuration *conf, struct usb_function *func)
     audio->pcm->private_data = audio;
 
 	snd_pcm_set_ops(audio->pcm, SNDRV_PCM_STREAM_PLAYBACK, &ipod_audio_pcm_ops);
+	
+	#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,1,0)
+	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,snd_dma_continuous_data(GFP_KERNEL), 0, BUFFER_BYTES_MAX);
+	#else
+	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,NULL, 0, BUFFER_BYTES_MAX);
+	#endif
+	
+	
 	snd_pcm_lib_preallocate_pages_for_all(audio->pcm, SNDRV_DMA_TYPE_CONTINUOUS,
 										  snd_dma_continuous_data(GFP_KERNEL), 0, BUFFER_BYTES_MAX);
 	ret = snd_card_register(audio->card);

--- a/gadget/ipod_hid.c
+++ b/gadget/ipod_hid.c
@@ -629,10 +629,19 @@ DECLARE_USB_FUNCTION(ipod_hid, ipod_hid_alloc_inst, ipod_hid_alloc);
 
 static int __init ipod_hid_mod_init(void)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
 	ipod_hid_class = class_create(THIS_MODULE, "iap");
 	if(IS_ERR(ipod_hid_class)) {
 		return PTR_ERR(ipod_hid_class);
-	}
+	}	
+#else
+	ipod_hid_class = class_create("iap");
+	if(IS_ERR(ipod_hid_class)) {
+		return PTR_ERR(ipod_hid_class);
+	}	
+#endif
+
+
 
 
 	return usb_function_register(&ipod_hidusb_func);


### PR DESCRIPTION
Fixed compile errors in ipod_audio and ipod_hid that were creating compile time errors on linux kernel < 6.1